### PR TITLE
Gallery 엔티티 정의

### DIFF
--- a/src/main/java/likelion8/backend/domain/Gallery.java
+++ b/src/main/java/likelion8/backend/domain/Gallery.java
@@ -1,0 +1,34 @@
+package likelion8.backend.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Gallery {
+
+    /*
+    * @Id: id라는 컬럼을 기본키(primary key)로 설정
+    * @GeneratedValue: 인스턴스 생성 때, 기본키를 자동으로 생성
+    * GenerationType.IDENTITY: 기본키 생성을 데이터베이스에 위임
+    * (다른 정책으로는 SEQUENCE, TABLE 등등...) JPA 기본키 생성 전략에 찾아보시길 추천!
+    */
+    @Id //
+    @GeneratedValue(strategy = GenerationType.IDENTITY)//인스턴스 생성 때, 기본키를 자동으로 생성
+    private Long id; // Integer보다 큰 범위를 저장할 수 있는 타입
+
+    private String image; // 이미지 파일을 직접 저장하지 않고, 접근할 수 있는 URL만 저장(가장 기본적인 방식)
+
+    private String title;
+
+    private String description;
+
+    private LocalDateTime lastUpdate; // 최근 수정 시간을 "2025-05-10 16:32:56" 처럼 날짜와 시간을 저장
+}


### PR DESCRIPTION
# 변경 파일
- src > main > java > likelion8.backend(이름은 다를 수 있음)
- likelion8.backend 폴더를 우클릭 후, 새 패키지 생성 (이름은 domain)
- domain 패키지 안에 Gallery라는 이름으로 클래스 생성

# 설명
**Gallery 클래스 위에 붙여야할 어노테이션**             
- @Entity: 이 클래스는 DB 테이블과 매핑된다는 것을 명시
- @Getter: 보통 Setter는 설정하지 않고 Getter만 생성
- @NoArgsConstructor: 기본 생성자는 반드시 생성해줘야 함 ()기본 생성자가 없으면 JPA가 예외를 던집니다

# 기타
- API 명세서 페이지 안에 있는 스키마대로 속성 정의
- 속성 설명은 주석에 포함
![image](https://github.com/user-attachments/assets/eca8aba4-ab54-409e-8149-e0c9131df3c6)