### PR TITLE
POST /api/galleries

### DIFF
--- a/src/main/java/likelion8/backend/config/WebConfig.java
+++ b/src/main/java/likelion8/backend/config/WebConfig.java
@@ -1,0 +1,33 @@
+package likelion8.backend.config;
+
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        try {
+            // "./images" 이렇게 상대 경로로 폴더 위치를 가져옴
+            // 이후 "/Users/you/project/images" 처럼 절대 경로로 변환
+            Path imageDir = Paths.get("images").toAbsolutePath();
+
+            // 폴더가 존재하지 않으면 생성
+            if (Files.notExists(imageDir)) {
+                Files.createDirectories(imageDir);
+            }
+
+            // "/images"로 시작하는 url에 "images" 폴더 안에 있는 사진들을 매핑
+            registry.addResourceHandler("/images/**")
+                    .addResourceLocations(imageDir.toUri().toString());
+
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 디렉토리를 생성하거나 설정하는 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/likelion8/backend/controller/GalleryController.java
+++ b/src/main/java/likelion8/backend/controller/GalleryController.java
@@ -1,13 +1,16 @@
 package likelion8.backend.controller;
 
+import likelion8.backend.dto.GalleryRequestDto;
 import likelion8.backend.dto.GalleryResponseDto;
 import likelion8.backend.service.GalleryService;
+import likelion8.backend.service.ImageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController //RESTfull 웹 서비스를 만들 때 사용하는 어노테이션. html페이지가 아니라 api 응답을 주고받는 컨트롤러
@@ -15,7 +18,8 @@ import java.util.List;
 @RequiredArgsConstructor //아래 final로 선언된 필드들만 골라서 생성자를 자동으로 생성!
 public class GalleryController {
 
-    private final GalleryService galleryService; // (컨트롤러 -> 서비스 -> 레포지토리) 컨트롤러에서는 서비스를 사용해서 로직 작성
+    private final GalleryService galleryService; // (컨트롤러 -> 서비스 -> 레포지토리) 컨트롤러에서는 서비스를 사용해서 로직
+    private final ImageService imageService;
 
     @GetMapping // GET 요청을 받는다는 것을 명시 (GET /api/galleries)
     public ResponseEntity<List<GalleryResponseDto>> getGalleries() {
@@ -23,6 +27,23 @@ public class GalleryController {
         // 서비스에 정의해줬던 메소드를 사용해서 컨트롤러 로직 작성
         List<GalleryResponseDto> galleries = galleryService.getAllGalleries();
         return ResponseEntity.ok(galleries); // code: 200 OK, response body에는 gallereis가 들어감
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> postGalleries(
+            @RequestPart("image") MultipartFile image,
+            @RequestPart("data") GalleryRequestDto data
+    ) {
+        String imageUrl = "";
+        try {
+            imageUrl = imageService.saveImageGetUrl(image);
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 업로드 과정에서 문제가 생겼습니다.");
+        }
+
+        galleryService.createGallery(data, imageUrl);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 

--- a/src/main/java/likelion8/backend/controller/GalleryController.java
+++ b/src/main/java/likelion8/backend/controller/GalleryController.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class GalleryController {
 
     private final GalleryService galleryService; // (컨트롤러 -> 서비스 -> 레포지토리) 컨트롤러에서는 서비스를 사용해서 로직
-    private final ImageService imageService;
+    private final ImageService imageService; // post 요청에서 사용할 이미지 서비스
 
     @GetMapping // GET 요청을 받는다는 것을 명시 (GET /api/galleries)
     public ResponseEntity<List<GalleryResponseDto>> getGalleries() {
@@ -29,21 +29,21 @@ public class GalleryController {
         return ResponseEntity.ok(galleries); // code: 200 OK, response body에는 gallereis가 들어감
     }
 
-    @PostMapping
+    @PostMapping // POST 요청을 받는다는 것을 명시 (POST /api/galleries)
     public ResponseEntity<Void> postGalleries(
-            @RequestPart("image") MultipartFile image,
-            @RequestPart("data") GalleryRequestDto data
+            @RequestPart("image") MultipartFile image, // 파일 형식의 데이터
+            @RequestPart("data") GalleryRequestDto data // json 형식의 데이터
     ) {
         String imageUrl = "";
         try {
-            imageUrl = imageService.saveImageGetUrl(image);
+            imageUrl = imageService.saveImageGetUrl(image); // 이미지를 저장하고 url을 받아오는 메소드
         } catch (IOException e) {
             throw new RuntimeException("이미지 업로드 과정에서 문제가 생겼습니다.");
         }
 
-        galleryService.createGallery(data, imageUrl);
+        galleryService.createGallery(data, imageUrl); // 직접 정의한 Gallery 생성 메소드 사용
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED).build(); // 상태코드: 201 Created, response body는 없습니다!
     }
 
 

--- a/src/main/java/likelion8/backend/domain/Gallery.java
+++ b/src/main/java/likelion8/backend/domain/Gallery.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import likelion8.backend.dto.GalleryRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,4 +32,14 @@ public class Gallery {
     private String description;
 
     private LocalDateTime lastUpdate; // 최근 수정 시간을 "2025-05-10 16:32:56" 처럼 날짜와 시간을 저장
+
+    public Gallery(GalleryRequestDto dto) {
+        this.title = dto.getTitle();
+        this.description = dto.getDescription();
+        this.lastUpdate = LocalDateTime.now();
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
 }

--- a/src/main/java/likelion8/backend/domain/Gallery.java
+++ b/src/main/java/likelion8/backend/domain/Gallery.java
@@ -33,12 +33,14 @@ public class Gallery {
 
     private LocalDateTime lastUpdate; // 최근 수정 시간을 "2025-05-10 16:32:56" 처럼 날짜와 시간을 저장
 
+    // dto(json)를 인스턴스로 변환해주는 생성자
     public Gallery(GalleryRequestDto dto) {
         this.title = dto.getTitle();
         this.description = dto.getDescription();
         this.lastUpdate = LocalDateTime.now();
     }
 
+    // Setter
     public void setImage(String image) {
         this.image = image;
     }

--- a/src/main/java/likelion8/backend/dto/GalleryRequestDto.java
+++ b/src/main/java/likelion8/backend/dto/GalleryRequestDto.java
@@ -1,0 +1,12 @@
+package likelion8.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GalleryRequestDto {
+    private Long id;
+    private String title;
+    private String description;
+}

--- a/src/main/java/likelion8/backend/dto/GalleryRequestDto.java
+++ b/src/main/java/likelion8/backend/dto/GalleryRequestDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GalleryRequestDto {
+    // 클라이언트 -> 서버로 보내는 요청의 형태를 정의 (이미지는 json이 아닌 파일 형태로 받기 때문에 제외)
     private Long id;
     private String title;
     private String description;

--- a/src/main/java/likelion8/backend/service/GalleryService.java
+++ b/src/main/java/likelion8/backend/service/GalleryService.java
@@ -1,6 +1,7 @@
 package likelion8.backend.service;
 
 import likelion8.backend.domain.Gallery;
+import likelion8.backend.dto.GalleryRequestDto;
 import likelion8.backend.dto.GalleryResponseDto;
 import likelion8.backend.repository.GalleryRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,5 +25,11 @@ public class GalleryService {
         return galleries.stream().map(
                 gallery -> new GalleryResponseDto(gallery)
         ).toList(); // 마지막으로 리스트 타입으로 변환 (최종 형태는 List<GalleryResponseDto>)
+    }
+
+    public void createGallery(GalleryRequestDto dto, String imageUrl) {
+        Gallery gallery = new Gallery(dto);
+        gallery.setImage(imageUrl);
+        galleryRepository.save(gallery);
     }
 }

--- a/src/main/java/likelion8/backend/service/GalleryService.java
+++ b/src/main/java/likelion8/backend/service/GalleryService.java
@@ -27,9 +27,10 @@ public class GalleryService {
         ).toList(); // 마지막으로 리스트 타입으로 변환 (최종 형태는 List<GalleryResponseDto>)
     }
 
+    // 프론트에서 데이터 보냃 때, 주의!!
     public void createGallery(GalleryRequestDto dto, String imageUrl) {
-        Gallery gallery = new Gallery(dto);
-        gallery.setImage(imageUrl);
-        galleryRepository.save(gallery);
+        Gallery gallery = new Gallery(dto); // 전달받은 json 데이터로 Gallery 인스턴스 생성
+        gallery.setImage(imageUrl); // 이미지 업로드 과정을 거쳐서 받은 url을 인스턴스에 추가로 설정
+        galleryRepository.save(gallery); // DB에 저장 (save 메소드는 JpaRepository에서 기본으로 제공)
     }
 }

--- a/src/main/java/likelion8/backend/service/ImageService.java
+++ b/src/main/java/likelion8/backend/service/ImageService.java
@@ -11,19 +11,25 @@ import java.util.UUID;
 @Service
 public class ImageService {
 
+    // 이미지를 저장할 폴더의 위치를 미리 상수로 정의
     private final Path imageDir = Paths.get("images").toAbsolutePath();
 
+    // 이미지를 저장하고 접근할 수 있는 url을 반환하는 메소드
     public String saveImageGetUrl(MultipartFile image) throws IOException{
-        String originalFilename = image.getOriginalFilename();
-        String extension = getExtension(originalFilename);
+        String originalFilename = image.getOriginalFilename(); // 이미지 파일의 원본 이름
+        String extension = getExtension(originalFilename); // 확장자만 추출 (.png .jpg)
+
+        // 저장되는 파일의 이름은 "랜덤 문자열.png" 형식
         String savedFilename = UUID.randomUUID().toString() + "." + extension;
 
+        // .../imageDir/savedFilename 으로 경로를 설정하는 메소드 (.../images/e2dsf2dgn.png) 이런 식의 경로가 됩니다.
         Path savedPath = imageDir.resolve(savedFilename);
-        image.transferTo(savedPath.toFile());
+        image.transferTo(savedPath.toFile()); // 실제 이미지 파일을 저장
 
-        return "/images/" + savedFilename;
+        return "/images/" + savedFilename; // 저장한 이미지를 조회할 수 있는 url 반환 (앞서 WebConfig에서 매핑 해줬음)
     }
 
+    // 이미지 파일의 확장자만 추출하는 메소드
     private String getExtension(String filename) throws IOException{
         if (filename == null || filename.isBlank() || !filename.contains(".")) {
             throw new IOException("확장자가 없는 이미지 파일입니다.");

--- a/src/main/java/likelion8/backend/service/ImageService.java
+++ b/src/main/java/likelion8/backend/service/ImageService.java
@@ -1,0 +1,33 @@
+package likelion8.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+public class ImageService {
+
+    private final Path imageDir = Paths.get("images").toAbsolutePath();
+
+    public String saveImageGetUrl(MultipartFile image) throws IOException{
+        String originalFilename = image.getOriginalFilename();
+        String extension = getExtension(originalFilename);
+        String savedFilename = UUID.randomUUID().toString() + "." + extension;
+
+        Path savedPath = imageDir.resolve(savedFilename);
+        image.transferTo(savedPath.toFile());
+
+        return "/images/" + savedFilename;
+    }
+
+    private String getExtension(String filename) throws IOException{
+        if (filename == null || filename.isBlank() || !filename.contains(".")) {
+            throw new IOException("확장자가 없는 이미지 파일입니다.");
+        }
+        return filename.substring(filename.lastIndexOf(".")+1);
+    }
+}


### PR DESCRIPTION
### 추가된 코드가 비교적 많습니다

# 프로젝트 구조
![image](https://github.com/user-attachments/assets/20b5c930-4b7f-4f2b-9fe3-521244a6e8fd)

# 주요 변경 사항
- 프론트에서 보낸 이미지를 백엔드 폴더에 저장 -> 저장한 이미지를 조회할 수 있는 url 생성 -> 프론트에서는 이 url로 이미지 조회
- 이미지 업로드를 위한 설정이 있는 WebConfig, 이미지 업로드와 관련된 로직이 있는 ImageService 작성
- POST 요청을 받을 컨트롤러 메소드 추가 (파일 형식의 image, json 형식의 data를 프론트로부터 전달받음)

# WebConfig
![image](https://github.com/user-attachments/assets/56645ffb-7605-430a-8cfd-62ce4104eccb)

# ImageService
![image](https://github.com/user-attachments/assets/bc46adb8-8aab-4d84-8bda-ff258d119511)

# GalleryService
![image](https://github.com/user-attachments/assets/c22b9779-b4fb-4518-bc6f-c24162f473c0)

# GalleryController
![image](https://github.com/user-attachments/assets/bf0faf7e-90b4-480e-a175-7154c75a2aa7)

# GalleryRequestDto
![image](https://github.com/user-attachments/assets/ed98d9e6-b8a4-4cde-93b0-5c059ce97549)
